### PR TITLE
Fix wake-word array processing

### DIFF
--- a/script.js
+++ b/script.js
@@ -71,7 +71,8 @@ class MinigolfApp {
             wakeWordRecognition.continuous = true;
             wakeWordRecognition.lang = 'de-DE';
             wakeWordRecognition.onresult = (event) => {
-                const transcript = event.results[0][0].transcript.toLowerCase();
+                const results = event.results;
+                const transcript = results[results.length - 1][0].transcript.toLowerCase();
                 console.log("Wake-word erkannt:", transcript);
                 this.wakeWordStatus.textContent = `Wake-word erkannt: ${transcript}`;
                 if (transcript.includes('computer')) {
@@ -79,6 +80,7 @@ class MinigolfApp {
                 } else {
                     console.log(event);
                 }
+                this.clearArray(results);
             };
             wakeWordRecognition.onend = () => {
                 console.log("Wake-word Erkennung beendet, starte neu");
@@ -379,6 +381,10 @@ class MinigolfApp {
         if (this.wakeWordRecognition && !this.isSpeaking) {
             this.wakeWordRecognition.start();
         }
+    }
+
+    clearArray(array) {
+        array.length = 0;
     }
 }
 


### PR DESCRIPTION
Fixes #6

Update wake-word recognition to search in the last entry of the array and clear the array after processing.

* **Wake-word recognition**
  - Modify `onresult` event handler to process the last entry of the array.
  - Add `clearArray` method to clear the array after processing the wake-word.
  - Call `clearArray` method in the `onresult` event handler.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rdmueller/birdie-minigolf/issues/6?shareId=54c8f0be-27b4-4620-90f5-b9db1c79b042).