### PR TITLE
Add feedback

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,6 +17,7 @@ Die Minigolf Scoreboard App ist eine webbasierte Anwendung, die es Spielern erm�
 * Speichern und Laden von Spielen
 * Teilen von Spielen mit anderen Spielern
 * Responsive Design für verschiedene Bildschirmgrößen
+* System reagiert mit "OK" als gesprochenes Wort und sichtbar auf dem Bildschirm, wenn das Schlüsselwort erkannt wird
 
 == Dateien
 
@@ -88,6 +89,7 @@ Die App unterstützt folgende Sprachbefehle:
 * "Spieler [Name] hinzufügen": Fügt einen neuen Spieler hinzu
 * "Bahn abschließen": Schließt die aktuelle Bahn ab
 * "Punktzahl für [Spieler] [Zahl]": Aktualisiert die Punktzahl eines Spielers
+* "OK": System reagiert mit "OK" als gesprochenes Wort und sichtbar auf dem Bildschirm, wenn das Schlüsselwort erkannt wird
 
 == Technische Details
 

--- a/index.html
+++ b/index.html
@@ -29,8 +29,8 @@
         <div style="margin-top: 20px; text-align: center; font-size: 14px; color: #666;">
             Sprachbefehle: "Spieler [Name] hinzufügen", "Bahn abschließen", "Punktzahl für [Spieler] [Zahl]"
         </div>
-        <div id="speechRecognitionResult"></div>
-        <div id="wakeWordStatus"></div>
+        <div id="speechRecognitionResult">OK</div>
+        <div id="wakeWordStatus">OK</div>
     </div>
     <div id="footer" class="container">
         <a href="https://github.com/rdmueller/birdie-minigolf">source</a>

--- a/script.js
+++ b/script.js
@@ -77,6 +77,9 @@ class MinigolfApp {
                 this.wakeWordStatus.textContent = `Wake-word erkannt: ${transcript}`;
                 if (transcript.includes('computer')) {
                     this.startListening();
+                    this.wakeWordStatus.textContent = 'OK';
+                    const utterance = new SpeechSynthesisUtterance('OK');
+                    window.speechSynthesis.speak(utterance);
                 } else {
                     console.log(event);
                 }


### PR DESCRIPTION
Fixes #9

Add feedback response when the keyword is recognized.

* **script.js**
  - Update `initializeWakeWordDetection` to display "OK" and speak "OK" when the keyword is recognized.
* **index.html**
  - Set initial content of `speechRecognitionResult` and `wakeWordStatus` elements to "OK".
* **README.adoc**
  - Update features to include the new "OK" response functionality.
  - Add "OK" response to the list of supported voice commands.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rdmueller/birdie-minigolf/issues/9?shareId=2ed4cf33-e661-4c01-ac78-144ceb70fa00).